### PR TITLE
Fix negative sleep calls

### DIFF
--- a/src/schedule.cr
+++ b/src/schedule.cr
@@ -81,11 +81,11 @@ module Schedule
     now = Time.now
     case interval
     when :minute
-      now.at_end_of_minute - now
+      now.at_end_of_minute - now + 1.millisecond
     when :hour
-      now.at_end_of_hour - now
+      now.at_end_of_hour - now + 1.millisecond
     when :day
-      now.at_end_of_day - now
+      now.at_end_of_day - now + 1.millisecond
     else
       raise InvalidTimeException.new
     end


### PR DESCRIPTION
#5 introduced ```Schedule.every(:minute)``` feature, but given the [return](https://github.com/crystal-lang/crystal/blob/e2a1389e8165fb097c785524337d7bb7b550a086/src/time.cr#L480) of ```#at_end_of_*``` methods is not exactly the next execution time we are expecting (1 millisecond earlier), this may result on a negative interval when calling ```sleep``` causing this exception:

```crystal
Schedule.every :minute do
  puts Time.now
  puts Time.now.millisecond
  puts Time.now.second
end
sleep
```

```
$ crystal test.cr 
2017-10-25 10:34:00 -0200
1
0
2017-10-25 10:35:00 -0200
2
0
2017-10-25 10:36:00 -0200
2
0
2017-10-25 10:37:00 -0200
1
0
2017-10-25 10:38:00 -0200
1
0
2017-10-25 10:39:00 -0200
1
0
2017-10-25 10:40:00 -0200
1
0
2017-10-25 10:41:00 -0200
1
0
2017-10-25 10:42:00 -0200
2
0
2017-10-25 10:43:00 -0200
0
0
2017-10-25 10:44:00 -0200
1
0
2017-10-25 10:44:59 -0200
999
59
Unhandled exception in spawn:
Sleep seconds must be positive (ArgumentError)
0x454527: *CallStack::unwind:Array(Pointer(Void)) at ??
0x4520b6: sleep at /opt/crystal/src/concurrent.cr 13:3
0x452082: sleep at /opt/crystal/src/concurrent.cr 22:3
0x451d1b: ~procProc(Nil) at /opt/crystal/src/kernel.cr 82:3
0x465b0e: run at /opt/crystal/src/fiber.cr 255:3
0x450d76: ~proc2Proc(Fiber, (IO::FileDescriptor | Nil)) at /opt/crystal/src/concurrent.cr 61:3
0x0: ??? at ??
```

Adding ```1.millisecond``` should keep us safe. Any thoughts @coderhs?