### PR TITLE
Fix compatibility with Crystal v0.33+

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,13 +1,18 @@
 name: schedule
-version: 0.2.1
+version: 0.2.2
 
 authors:
   - Hugo Abonizio <hugo_abonizio@hotmail.com>
 
-crystal: 0.26.1
+crystal: 0.35.1
 
 license: MIT
 
+dependencies:
+  future:
+    github: crystal-community/future.cr
+
 development_dependencies:
   timecop:
-    github: TobiasGSmollett/timecop.cr
+    github: crystal-community/timecop.cr
+    version: 0.4.0

--- a/spec/schedule_spec.cr
+++ b/spec/schedule_spec.cr
@@ -143,14 +143,14 @@ describe Schedule do
 
   context ".calculate_interval" do
     it "should return 30 seconds when scheduled at 30th second of a minute" do
-      time = Time.new(2017, 10, 15, 15, 0, 30)
+      time = Time.local(2017, 10, 15, 15, 0, 30)
       Timecop.freeze(time) do
         Schedule.calculate_interval(:minute).to_f.ceil.should eq(30.seconds.to_i)
       end
     end
 
     it "should return 19 minutes when scheduled at 2:31 PM" do
-      time = Time.new(2017, 10, 15, 14, 31, 0)
+      time = Time.local(2017, 10, 15, 14, 31, 0)
       Timecop.freeze(time) do
         Schedule.calculate_interval(:hour).to_f.ceil.should eq(29.minutes.to_i)
       end
@@ -158,7 +158,7 @@ describe Schedule do
 
     context ":sunday, '16:00:00'" do
       it "should return 1 hour when executed at 3 pm on a Sunday'" do
-        time = Time.new(2017, 10, 15, 15, 0, 0)
+        time = Time.local(2017, 10, 15, 15, 0, 0)
         Timecop.freeze(time) do
           Schedule.calculate_interval(:sunday, "16:00:00").to_s.should eq "01:00:00"
         end
@@ -167,14 +167,14 @@ describe Schedule do
 
     context ":sunday, '16:00:00'" do
       it "should return 6 days and 23 hours when executed at 5 PM on a Sunday" do
-        time = Time.new(2017, 10, 15, 17, 0, 0)
+        time = Time.local(2017, 10, 15, 17, 0, 0)
         Timecop.freeze(time) do
           Schedule.calculate_interval(:sunday, "16:00:00").to_s.should eq "6.23:00:00"
         end
       end
 
       it "should return 3 hours when executed at 1 PM" do
-        time = Time.new(2017, 10, 15, 13, 0, 0)
+        time = Time.local(2017, 10, 15, 13, 0, 0)
         Timecop.freeze(time) do
           Schedule.calculate_interval(:sunday, "16:00:00").to_s.should eq "03:00:00"
         end
@@ -183,14 +183,14 @@ describe Schedule do
 
     context ":sunday, ['16:00:00', '18:00:00']" do
       it "should return 1 hour when scheduled at Sunday 5 PM" do
-        time = Time.new(2017, 10, 15, 17, 0, 0)
+        time = Time.local(2017, 10, 15, 17, 0, 0)
         Timecop.freeze(time) do
           Schedule.calculate_interval(:sunday, ["16:00:00", "18:00:00"]).to_s.should eq "01:00:00"
         end
       end
 
       it "should return 6 days 21 hours when scheduled at Sunday 7 PM" do
-        time = Time.new(2017, 10, 15, 19, 0, 0)
+        time = Time.local(2017, 10, 15, 19, 0, 0)
         Timecop.freeze(time) do
           Schedule.calculate_interval(:sunday, ["16:00:00", "18:00:00"]).to_s.should eq "6.21:00:00"
         end
@@ -199,14 +199,14 @@ describe Schedule do
 
     context ":day, at: '16:00:00'" do
       it "should return 1 hour when scheduled at 3 PM" do
-        time = Time.new(2017, 10, 15, 15, 0, 0)
+        time = Time.local(2017, 10, 15, 15, 0, 0)
         Timecop.freeze(time) do
           Schedule.calculate_interval(:day, "16:00:00").to_s.should eq "01:00:00"
         end
       end
 
       it "should return 23 hour when scheduled at 5 PM" do
-        time = Time.new(2017, 10, 15, 17, 0, 0)
+        time = Time.local(2017, 10, 15, 17, 0, 0)
         Timecop.freeze(time) do
           Schedule.calculate_interval(:day, "16:00:00").to_s.should eq "23:00:00"
         end
@@ -215,21 +215,21 @@ describe Schedule do
 
     context ":day, at: ['16:00:00', '18:00:00']" do
       it "should return 1 hour when scheduled at 3 PM" do
-        time = Time.new(2017, 10, 15, 15, 0, 0)
+        time = Time.local(2017, 10, 15, 15, 0, 0)
         Timecop.freeze(time) do
           Schedule.calculate_interval(:day, ["16:00:00", "18:00:00"]).to_s.should eq "01:00:00"
         end
       end
 
       it "should return 1 hour 30 minute when scheduled at 4:30 PM" do
-        time = Time.new(2017, 10, 15, 16, 30, 0)
+        time = Time.local(2017, 10, 15, 16, 30, 0)
         Timecop.freeze(time) do
           Schedule.calculate_interval(:day, ["16:00:00", "18:00:00"]).to_s.should eq "01:30:00"
         end
       end
 
       it "should return 23 hour when scheduled at 9 PM" do
-        time = Time.new(2017, 10, 15, 19, 0, 0)
+        time = Time.local(2017, 10, 15, 19, 0, 0)
         Timecop.freeze(time) do
           Schedule.calculate_interval(:day, "16:00:00").to_s.should eq "21:00:00"
         end

--- a/spec/time_spec.cr
+++ b/spec/time_spec.cr
@@ -3,7 +3,7 @@ require "./spec_helper"
 describe Time do
   context ".change" do
     it "should change parameters based on hash" do
-      current_time = Time.new
+      current_time = Time.local
 
       new_time = current_time.change(year: 2016,
         month: 5,
@@ -16,14 +16,14 @@ describe Time do
     end
 
     it "should change just the parameters passed based on hash" do
-      current_time = Time.new
+      current_time = Time.local
 
       current_time.change(year: 2016).year.should eq 2016
       current_time.change(year: 2016).minute.should eq current_time.minute
     end
 
     it "should change the self object" do
-      time = Time.new(2016, 1, 1, 1, 1, 1)
+      time = Time.local(2016, 1, 1, 1, 1, 1)
 
       time = time.change(**{hour: 0, minute: 0, second: 0})
 

--- a/src/schedule.cr
+++ b/src/schedule.cr
@@ -78,7 +78,7 @@ module Schedule
   end
 
   def self.calculate_interval(interval : Symbol)
-    now = Time.now
+    now = Time.local
     case interval
     when :minute
       now.at_end_of_minute - now
@@ -92,7 +92,7 @@ module Schedule
   end
 
   def self.calculate_interval(interval : Symbol, at : String | Array(String))
-    current_time = Time.now
+    current_time = Time.local
     next_day = current_time.find_next(interval)
     next_datetime = next_time(next_day, at)
     next_datetime = if next_datetime == next_day

--- a/src/schedule/ext/time.cr
+++ b/src/schedule/ext/time.cr
@@ -7,7 +7,7 @@ struct Time
     hour ||= current_time.hour
     minute ||= current_time.minute
     second ||= current_time.second
-    Time.new(year, month, day, hour, minute, second)
+    Time.local(year, month, day, hour, minute, second)
   end
 
   def find_next(day : Symbol)

--- a/src/schedule/runner.cr
+++ b/src/schedule/runner.cr
@@ -1,3 +1,5 @@
+require "future"
+
 module Schedule
   class Runner
     @exception_handler : (Proc(Nil) | Proc(Exception))?


### PR DESCRIPTION
Some changes in `Time` and the extraction of [future.cr](https://github.com/crystal-community/future.cr) into a shard made this package broken in recent versions of Crystal. This PR fixes those issues.

Fix #14