### PR TITLE
Ignore Crystal version requirement of dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - run: crystal --version
       - checkout
-      - run: shards
+      - run: shards --ignore-crystal-version
       - run: crystal spec
 
 workflows:


### PR DESCRIPTION
Since `future.cr` requires `>= 0.34.0` and `timecop.cr` requires `>= 0.33.0` Crystal version, lets use this workaround to test on CI nightly.